### PR TITLE
Fixes some characters in the "Description" that are not being shown, replacing them with HTML character entities

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2,7 +2,7 @@
 
 /*
 	Plugin Name: Replace DIVs with FIGURE and FIGCAPTION
-	Description: Replace WordPress' &lt;div&gt;s with HTML5's &lt;figure&gt; and &lt;figcaption&gt; for images that are inserted with caption.
+	Description: Replace WordPress' &lt;div&gt;s with HTML5's &lt;figure&gt; and &lt;figcaption&gt;.
 	Version: 1.2
 	Author: Aaron T. Grogg
 	Author URI: http://aarontgrogg.com/

--- a/functions.php
+++ b/functions.php
@@ -2,7 +2,7 @@
 
 /*
 	Plugin Name: Replace DIVs with FIGURE and FIGCAPTION
-	Description: Replace WordPress' <div>s with HTML5's <figure> and <figcaption>.
+	Description: Replace WordPress&apos; &lt;div&gt;s with HTML5&apos;s &lt;figure&gt; and &lt;figcaption&gt;.
 	Version: 1.2
 	Author: Aaron T. Grogg
 	Author URI: http://aarontgrogg.com/

--- a/functions.php
+++ b/functions.php
@@ -2,7 +2,7 @@
 
 /*
 	Plugin Name: Replace DIVs with FIGURE and FIGCAPTION
-	Description: Replace WordPress&apos; &lt;div&gt;s with HTML5&apos;s &lt;figure&gt; and &lt;figcaption&gt;.
+	Description: Replace WordPress' &lt;div&gt;s with HTML5's &lt;figure&gt; and &lt;figcaption&gt; for images that are inserted with caption.
 	Version: 1.2
 	Author: Aaron T. Grogg
 	Author URI: http://aarontgrogg.com/


### PR DESCRIPTION
The characters in the "Description" `<` and `>` were not being shown in the WP backend. I have replaced them with HTML character entities.